### PR TITLE
chore: add `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+---
+name: ci
+
+'on':
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  build_path: ${{github.workspace}}/build
+
+jobs:
+  build_and_test:
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Display versions
+        run: |
+          gfortran --version
+          cmake --version
+
+      - name: Create Build Directory
+        run: cmake -E make_directory ${{env.build_path}}
+
+      - name: Configure CMake
+        working-directory: ${{env.build_path}}
+        run: cmake ../
+
+      - name: Build
+        working-directory: ${{env.build_path}}
+        run: cmake --build .
+
+      - name: Test
+        working-directory: ${{env.build_path}}
+        run: ctest
+...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,8 @@ jobs:
       - name: Test
         working-directory: ${{env.build_path}}
         run: ctest
+
+      - name: Run examples
+        working-directory: ${{env.build_path}}
+        run: make run_all_examples
 ...

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@
 
 .idea/
 
+/build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.16)
+project(FortranProject LANGUAGES Fortran)
+
+add_compile_options(-Wall -Wextra -Wpedantic)
+
+function(add_fortran_sources DIR SOURCES)
+    file(GLOB_RECURSE NEW_SOURCES "${DIR}/*.f90")
+    list(APPEND ${SOURCES} ${NEW_SOURCES})
+    set(${SOURCES} ${${SOURCES}} PARENT_SCOPE)
+endfunction()
+
+set(MODULE_SOURCES)
+add_fortran_sources(${CMAKE_SOURCE_DIR}/modules MODULE_SOURCES)
+
+add_library(modules STATIC ${MODULE_SOURCES})
+
+function(create_unique_name FILE_NAME OUTPUT_NAME)
+    file(RELATIVE_PATH REL_PATH "${CMAKE_SOURCE_DIR}" "${FILE_NAME}")
+    get_filename_component(CUR_EXT "${REL_PATH}" LAST_EXT)
+    string(REPLACE "/" "_" UNIQUE_NAME "${REL_PATH}")
+    string(REPLACE "${CUR_EXT}" "" UNIQUE_NAME "${UNIQUE_NAME}")
+    set(${OUTPUT_NAME} ${UNIQUE_NAME} PARENT_SCOPE)
+endfunction()
+
+
+file(GLOB_RECURSE TEST_FILES "${CMAKE_SOURCE_DIR}/tests/*.f90")
+
+foreach(TEST_FILE ${TEST_FILES})
+    create_unique_name(${TEST_FILE} TEST_NAME)
+    add_executable(${TEST_NAME} ${TEST_FILE})
+    target_link_libraries(${TEST_NAME} modules)
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+endforeach()
+
+file(GLOB_RECURSE EXAMPLE_FILES "${CMAKE_SOURCE_DIR}/examples/*.f90")
+
+foreach(EXAMPLE_FILE ${EXAMPLE_FILES})
+    create_unique_name(${EXAMPLE_FILE} EXAMPLE_NAME)
+    add_executable(${EXAMPLE_NAME} ${EXAMPLE_FILE})
+    target_link_libraries(${EXAMPLE_NAME} modules)
+    list(APPEND EXAMPLE_NAME_LIST run_${EXAMPLE_NAME})
+    add_custom_target(run_${EXAMPLE_NAME}
+        COMMAND ${EXAMPLE_NAME}
+        DEPENDS ${EXAMPLE_NAME}
+        COMMENT "Running example: ${EXAMPLE_NAME}")
+endforeach()
+
+enable_testing()
+
+add_custom_target(run_all_examples DEPENDS ${EXAMPLE_NAME_LIST})

--- a/examples/maths/euclid_gcd.f90
+++ b/examples/maths/euclid_gcd.f90
@@ -4,17 +4,11 @@ program euclid_gcd_program
     use gcd_module
     implicit none
     integer :: a, b, val
-    character(len=1024) :: msg
-    integer :: istat
 
-    print *, "Enter the two numbers (+ve integers): "
-    read(*, *, iostat=istat, iomsg=msg) a, b
-    if (istat /= 0) then
-        write(*, fmt='(2A)') 'error: ', trim(msg)
-        stop 1
-    end if
+    a = 56
+    b = 98
 
     val = gcd(a, b)
-    print *, 'The greatest common divisor is: ', val
+    print *, 'The greatest common divisor of ', a, ' and ', b, ' is: ', val
 
 end program euclid_gcd_program

--- a/examples/maths/fibonacci.f90
+++ b/examples/maths/fibonacci.f90
@@ -6,14 +6,9 @@ program example_fibonacci
     implicit none
     integer :: n
 
-    print *, 'Enter a number: '
-    read *, n
-    if (n <= 0) then
-        print *, 'Number must be a positive integer.'
-        stop 1
-    end if
+    n = 7
 
-    print *, 'The Fibonacci number for the specified position is:'
+    print *, 'The Fibonacci number for the position', n, ' is:'
     print *, 'Recursive solution: ', fib_rec(n)
     print *, 'Iterative solution: ', fib_itr(n)
 

--- a/examples/sorts/example_usage_heap_sort.f90
+++ b/examples/sorts/example_usage_heap_sort.f90
@@ -11,7 +11,6 @@ program test_heap_sort
 
     ! Initialize the test array
     array = (/ 12, 11, 13, 5, 6, 7, 3, 9, -1, 2, -12, 1 /)
-    n = size(array)
 
     ! Print the original array
     print *, "Original array:"


### PR DESCRIPTION
Fixes #13.

_It works on my end_, cf. vil02/Fortran#1, vil02/Fortran#2 (please have a look to [the action runs](https://github.com/vil02/Fortran/actions/workflows/ci.yml)).

The `CMakeLists.txt` is not perfect, but I think it is good enough for now:
- scans the `modules`, `tests` and `example` directories for `*.f90` files,
- all of the tests and examples are linked with all of the modules,
- the tests and the examples, have _pretty unique_ name: even if there would be two files with the same name in `tests/sorts` and `tests/some_other_algorithms` this would not cause any problem.

When this will be merged, there are few things on the _to do list_:
- ~make of all of the files in the `other` directory proper modules and add tests for them,~
- fix the warnings (currently there are few _unused variables_) (done in #26),
- add the `-Werror` flag (done in #26),
- generate coverage reports.