### PR TITLE
Minor synatx fix for the heap sort example

### DIFF
--- a/examples/sorts/example_usage_heap_sort.f90
+++ b/examples/sorts/example_usage_heap_sort.f90
@@ -11,7 +11,6 @@ program test_heap_sort
 
     ! Initialize the test array
     array = (/ 12, 11, 13, 5, 6, 7, 3, 9, -1, 2, -12, 1 /)
-    n = size(array)
 
     ! Print the original array
     print *, "Original array:"


### PR DESCRIPTION

Syntax-error fix: Second constant 'n' definition
   `14 |     n = size(array)`