### PR TITLE
chore: add `check_code_format.yml`

### DIFF
--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -33,4 +33,8 @@ jobs:
              git status --porcelain=v1
              exit 1
           fi
+
+      - name: Exact diff of needed reformatting
+        if: failure()
+        run: git diff
 ...

--- a/.github/workflows/check_code_format.yml
+++ b/.github/workflows/check_code_format.yml
@@ -1,0 +1,36 @@
+---
+name: check_code_format
+
+'on':
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  check_format_code:
+    name: check format code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install fprettify
+        run: pip install fprettify
+
+      - name: Display fprettify version
+        run: fprettify --version
+
+      - name: Format code
+        run: |
+          git clean -f -x -d
+          fprettify --indent 4 --recursive .
+
+      - name: Fail if needs reformatting
+        run: |
+          if [[ $(git status --porcelain) ]]; then
+             echo "please reformat/fprettify these files:"
+             git status --porcelain=v1
+             exit 1
+          fi
+...

--- a/examples/maths/factorial.f90
+++ b/examples/maths/factorial.f90
@@ -7,7 +7,7 @@ program factorial_program
     use factorial_module
     implicit none
 
-    Print*, factorial(5)
-    Print*, recursive_factorial(5)
+    Print *, factorial(5)
+    Print *, recursive_factorial(5)
 
 end program factorial_program

--- a/examples/searches/example_linear_search.f90
+++ b/examples/searches/example_linear_search.f90
@@ -8,12 +8,12 @@ program linear_search_program
 
     integer, dimension(5) :: array
 
-    array = (/ 540, 6, 10, 100, 3 /)
+    array = (/540, 6, 10, 100, 3/)
 
     !! Search for the number 6 in array.
-    print*, "Target = 6: ", linear_search(array, 6) !! Prints 2.
+    print *, "Target = 6: ", linear_search(array, 6) !! Prints 2.
 
     !! Search for the number 5 in array.
-    print*, "Target = 5: ", linear_search(array, 5) !! Prints -1 because item 5 is not found.
+    print *, "Target = 5: ", linear_search(array, 5) !! Prints -1 because item 5 is not found.
 
 end program linear_search_program

--- a/examples/searches/recursive_linear_search.f90
+++ b/examples/searches/recursive_linear_search.f90
@@ -8,12 +8,12 @@ program recursive_linear_search_example
 
     integer, dimension(5) :: array
 
-    array = (/ 306, 1005, 5, 62, 0 /)
+    array = (/306, 1005, 5, 62, 0/)
 
     !! Search for the number 62 in the array
-    print*, "Target = 62: ", recursive_linear_search(array, size(array), 62) !! Prints 4.
+    print *, "Target = 62: ", recursive_linear_search(array, size(array), 62) !! Prints 4.
 
     !! Search for the number 10 in the array
-    print*, "Target = 10: ", recursive_linear_search(array, size(array), 10) !! Prints -1 because item 10 is not found.
+    print *, "Target = 10: ", recursive_linear_search(array, size(array), 10) !! Prints -1 because item 10 is not found.
 
 end program recursive_linear_search_example

--- a/examples/sorts/example_recursive_bubble_sort.f90
+++ b/examples/sorts/example_recursive_bubble_sort.f90
@@ -11,11 +11,11 @@ program recursive_bubble_sort_example
     !! Fill the array with random numbers.
     call random_number(array)
 
-    print*, "Before:", array
+    print *, "Before:", array
 
     !! Bubble sort subroutine call.
     call recursive_bubble_sort(array, size(array))
 
-    print*, "After:", array
+    print *, "After:", array
 
 end program recursive_bubble_sort_example

--- a/examples/sorts/example_usage_bubble_sort.f90
+++ b/examples/sorts/example_usage_bubble_sort.f90
@@ -11,11 +11,11 @@ program bubble_sort_example
     !! Fill the array with random numbers
     call random_number(array)
 
-    print*, "Before:", array
+    print *, "Before:", array
 
     !! Call the bubble_sort subroutine to sort the array
     call bubble_sort(array)
 
-    print*, "After:", array
+    print *, "After:", array
 
 end program bubble_sort_example

--- a/examples/sorts/example_usage_gnome_sort.f90
+++ b/examples/sorts/example_usage_gnome_sort.f90
@@ -9,7 +9,7 @@ program test_gnome_sort
     integer :: n, i
 
     ! Initialize the test array
-    array = (/ -5, 2, 9, 1, 5, 6, -7, 8, 15, -20 /)
+    array = (/-5, 2, 9, 1, 5, 6, -7, 8, 15, -20/)
     n = size(array)
 
     ! Call gnome_sort from the module to sort the array

--- a/examples/sorts/example_usage_heap_sort.f90
+++ b/examples/sorts/example_usage_heap_sort.f90
@@ -10,7 +10,7 @@ program test_heap_sort
     integer, dimension(n) :: array(n)   ! Test array
 
     ! Initialize the test array
-    array = (/ 12, 11, 13, 5, 6, 7, 3, 9, -1, 2, -12, 1 /)
+    array = (/12, 11, 13, 5, 6, 7, 3, 9, -1, 2, -12, 1/)
 
     ! Print the original array
     print *, "Original array:"

--- a/examples/sorts/example_usage_merge_sort.f90
+++ b/examples/sorts/example_usage_merge_sort.f90
@@ -9,7 +9,7 @@ program test_merge_sort
     integer :: n, i
 
     ! Initialize the test array
-    array = (/ -2, 3, -10, 11, 99, 100000, 100, -200 /)
+    array = (/-2, 3, -10, 11, 99, 100000, 100, -200/)
     n = size(array)
 
     ! Call merge_sort from the module to sort the array

--- a/examples/sorts/example_usage_quick_sort.f90
+++ b/examples/sorts/example_usage_quick_sort.f90
@@ -9,7 +9,7 @@ program test_quick_sort
     integer :: n, i
 
     ! Initialize the test array
-    array = (/ 10, 7, 8, 9, 1, 5, -2, 12, 0, -5 /)
+    array = (/10, 7, 8, 9, 1, 5, -2, 12, 0, -5/)
     n = size(array)
 
     ! Print the original array

--- a/examples/sorts/example_usage_radix_sort.f90
+++ b/examples/sorts/example_usage_radix_sort.f90
@@ -13,7 +13,7 @@ program test_radix_sort
 
     ! Test for base 10
     print *, "Testing Radix Sort with base 10:"
-    array = (/ 170, 45, 75, 90, 802, 24, 2, 66, 15, 40 /)
+    array = (/170, 45, 75, 90, 802, 24, 2, 66, 15, 40/)
     n = size(array)
     call radix_sort(array, n, base10)
     print *, "Sorted array in base 10:"
@@ -23,7 +23,7 @@ program test_radix_sort
 
     ! Test for base 2
     print *, "Testing Radix Sort with base 2:"
-    array = (/ 1010, 1101, 1001, 1110, 0010, 0101, 1111, 0110, 1000, 0001 /) ! Binary values whose decimal: (/ 10, 13, 9, 14, 2, 5, 15, 6, 8, 1 /)
+    array = (/1010, 1101, 1001, 1110, 0010, 0101, 1111, 0110, 1000, 0001/) ! Binary values whose decimal: (/ 10, 13, 9, 14, 2, 5, 15, 6, 8, 1 /)
     n = size(array)
     call radix_sort(array, n, base2)
     print *, "Sorted binary array in Decimal:"
@@ -33,7 +33,7 @@ program test_radix_sort
 
     ! Test for base 16
     print *, "Testing Radix Sort with base 16:"
-    array = (/ 171, 31, 61, 255, 16, 5, 211, 42, 180, 0 /)  ! Hexadecimal values as decimal
+    array = (/171, 31, 61, 255, 16, 5, 211, 42, 180, 0/)  ! Hexadecimal values as decimal
     n = size(array)
     call radix_sort(array, n, base16)
     print *, "Sorted hexadecimal array in Decimal:"

--- a/modules/maths/factorial.f90
+++ b/modules/maths/factorial.f90
@@ -19,7 +19,7 @@ contains
 
         factorial_number = 1
         do while (counter > 1)
-            factorial_number = factorial_number * counter
+            factorial_number = factorial_number*counter
             counter = counter - 1
         end do
 
@@ -33,7 +33,7 @@ contains
         if (number .lt. 1) then
             factorial_number = 1
         else
-            factorial_number = number * recursive_factorial(number - 1)
+            factorial_number = number*recursive_factorial(number - 1)
         end if
 
     end function recursive_factorial

--- a/modules/searches/linear_search.f90
+++ b/modules/searches/linear_search.f90
@@ -8,7 +8,7 @@ contains
 
     !! This function searches for a target in a given collection.
     !! Returns the index of the found target or -1 if target is not found.
-    function linear_search (collection, target) result(target_index)
+    function linear_search(collection, target) result(target_index)
         integer, dimension(:), intent(in) :: collection   !! A collection for elements of type integer
         integer, intent(in)               :: target       !! Target value to be searched.
         integer                           :: target_index !! Target's index in the collection to return.

--- a/modules/searches/recursive_linear_search.f90
+++ b/modules/searches/recursive_linear_search.f90
@@ -26,7 +26,7 @@ contains
             target_index = index
         else
             !! Recursively search in the remaining part of the collection
-            target_index = recursive_linear_search(collection, index-1, target)
+            target_index = recursive_linear_search(collection, index - 1, target)
         end if
 
     end function recursive_linear_search

--- a/modules/sorts/bubble_sort.f90
+++ b/modules/sorts/bubble_sort.f90
@@ -8,7 +8,7 @@ module bubble_sort_module
 contains
 
     !! This subroutine sorts the collection using bubble sort.
-    subroutine bubble_sort (collection)
+    subroutine bubble_sort(collection)
         real, dimension(:), intent(inout) :: collection !! A collection of real numbers to be sorted
 
         integer :: i, j, collection_size
@@ -24,11 +24,11 @@ contains
             swapped = .false.
 
             do i = 1, j
-                if (collection(i) .gt. collection(i+1)) then
+                if (collection(i) .gt. collection(i + 1)) then
                     !! Swap values if they are out of order in [i, i+1] region
                     temp = collection(i)
-                    collection(i) = collection(i+1)
-                    collection(i+1) = temp
+                    collection(i) = collection(i + 1)
+                    collection(i + 1) = temp
 
                     swapped = .true. !! Set swapped flag to true
                 end if

--- a/modules/sorts/heap_sort.f90
+++ b/modules/sorts/heap_sort.f90
@@ -26,7 +26,7 @@ contains
         integer :: i
 
         ! Build the max heap
-        do i = n / 2, 1, -1
+        do i = n/2, 1, -1
             call heapify(array, n, i)
         end do
 
@@ -50,8 +50,8 @@ contains
         integer :: largest, left, right
 
         largest = i
-        left = 2 * i
-        right = 2 * i + 1
+        left = 2*i
+        right = 2*i + 1
 
         ! Is Left Child is larger than Root?
         if (left <= n .and. array(left) > array(largest)) then

--- a/modules/sorts/merge_sort.f90
+++ b/modules/sorts/merge_sort.f90
@@ -14,7 +14,7 @@
 !! - A sorted array of integers.
 !!
 module merge_sort_module
-implicit none
+    implicit none
 
 contains
 
@@ -30,14 +30,14 @@ contains
         if (n <= 1) return
 
         ! Calculate the middle point to split the array
-        middle = n / 2
+        middle = n/2
 
         ! Allocate space for the two halves
-        allocate(left_half(middle), right_half(n - middle), sorted_array(n))
+        allocate (left_half(middle), right_half(n - middle), sorted_array(n))
 
         ! Split array into two halves
         left_half = array(1:middle)
-        right_half = array(middle+1:n)
+        right_half = array(middle + 1:n)
 
         ! Recursively sort each half
         call merge_sort(left_half, middle)
@@ -50,7 +50,7 @@ contains
         array = sorted_array
 
         ! Deallocate the temporary arrays
-        deallocate(left_half, right_half, sorted_array)
+        deallocate (left_half, right_half, sorted_array)
 
     end subroutine merge_sort
 

--- a/modules/sorts/radix_sort.f90
+++ b/modules/sorts/radix_sort.f90
@@ -37,9 +37,9 @@ contains
         exp = 1
 
         ! Perform Counting Sort for each digit
-        do while (max_digit / exp >= 1)
+        do while (max_digit/exp >= 1)
             call counting_sort(array, n, exp, base)
-            exp = exp * base
+            exp = exp*base
         end do
 
     end subroutine radix_sort
@@ -55,14 +55,14 @@ contains
         integer, dimension(:), allocatable :: count, output
 
         count_size = base
-        allocate(count(count_size), output(n))
+        allocate (count(count_size), output(n))
 
         ! Initialize count array
         count = 0
 
         ! Store count of occurrences
         do i = 1, n
-            digit = mod(array(i) / exp, base)
+            digit = mod(array(i)/exp, base)
             count(digit + 1) = count(digit + 1) + 1
         end do
 
@@ -73,7 +73,7 @@ contains
 
         ! Build the output array
         do i = n, 1, -1
-            digit = mod(array(i) / exp, base)
+            digit = mod(array(i)/exp, base)
             output(count(digit + 1)) = array(i)
             count(digit + 1) = count(digit + 1) - 1
         end do
@@ -82,7 +82,7 @@ contains
         array = output
 
         ! Deallocate temporary arrays
-        deallocate(count, output)
+        deallocate (count, output)
 
     end subroutine counting_sort
 

--- a/tests/sorts/tests_gnome_sort.f90
+++ b/tests/sorts/tests_gnome_sort.f90
@@ -11,55 +11,55 @@ program tests_gnome_sort
 
     ! Test 1: Repeated elements
     print *, "Test 1: Array with repeated elements"
-    array = (/ 5, 3, 8, 3, 1, 5, 7, 5, 10, 7, 3, 1 /)
+    array = (/5, 3, 8, 3, 1, 5, 7, 5, 10, 7, 3, 1/)
     call run_test(array)
 
     ! Test 2: Already sorted array
     print *, "Test 2: Already sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 1, 2, 3, 4, 5, 6, 7, 8 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/1, 2, 3, 4, 5, 6, 7, 8/)
     call run_test(array)
 
     ! Test 3: Reverse sorted array
     print *, "Test 3: Reverse sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 8, 7, 6, 5, 4, 3, 2, 1 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/8, 7, 6, 5, 4, 3, 2, 1/)
     call run_test(array)
 
     ! Test 4: Array with all negative numbers
     print *, "Test 4: Array with all negative numbers"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ -1, -5, -3, -7, -2, -12, -15, -4 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/-1, -5, -3, -7, -2, -12, -15, -4/)
     call run_test(array)
 
     ! Test 5: Single element array
     print *, "Test 5: Single element array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(1))
-    array = (/ 42 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(1))
+    array = (/42/)
     call run_test(array)
 
     ! Test 6: Array with identical elements
     print *, "Test 6: Array with identical elements"
-    if (allocated(array)) deallocate(array)
-    allocate(array(5))
-    array = (/ 7, 7, 7, 7, 7 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(5))
+    array = (/7, 7, 7, 7, 7/)
     call run_test(array)
 
     ! Test 7: Array with alternating high and low values
     print *, "Test 7: Array with alternating high and low values"
-    if (allocated(array)) deallocate(array)
-    allocate(array(6))
-    array = (/ 1, 1000, 2, 999, 3, 998 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(6))
+    array = (/1, 1000, 2, 999, 3, 998/)
     call run_test(array)
 
     ! Test 8: Empty array
     print *, "Test 8: Empty array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(0))
+    if (allocated(array)) deallocate (array)
+    allocate (array(0))
     call run_test(array)
 
 contains
@@ -88,6 +88,5 @@ contains
 
         print *, ""
     end subroutine run_test
-
 
 end program tests_gnome_sort

--- a/tests/sorts/tests_heap_sort.f90
+++ b/tests/sorts/tests_heap_sort.f90
@@ -11,55 +11,55 @@ program tests_heap_sort
 
     ! Test 1: Repeated elements
     print *, "Test 1: Array with repeated elements"
-    array = (/ 5, 3, 8, 3, 1, 5, 7, 5, 10, 7, 3, 1 /)
+    array = (/5, 3, 8, 3, 1, 5, 7, 5, 10, 7, 3, 1/)
     call run_test(array)
 
     ! Test 2: Already sorted array
     print *, "Test 2: Already sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 1, 2, 3, 4, 5, 6, 7, 8 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/1, 2, 3, 4, 5, 6, 7, 8/)
     call run_test(array)
 
     ! Test 3: Reverse sorted array
     print *, "Test 3: Reverse sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 8, 7, 6, 5, 4, 3, 2, 1 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/8, 7, 6, 5, 4, 3, 2, 1/)
     call run_test(array)
 
     ! Test 4: Array with all negative numbers
     print *, "Test 4: Array with all negative numbers"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ -1, -5, -3, -7, -2, -12, -15, -4 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/-1, -5, -3, -7, -2, -12, -15, -4/)
     call run_test(array)
 
     ! Test 5: Single element array
     print *, "Test 5: Single element array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(1))
-    array = (/ 42 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(1))
+    array = (/42/)
     call run_test(array)
 
     ! Test 6: Array with identical elements
     print *, "Test 6: Array with identical elements"
-    if (allocated(array)) deallocate(array)
-    allocate(array(5))
-    array = (/ 7, 7, 7, 7, 7 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(5))
+    array = (/7, 7, 7, 7, 7/)
     call run_test(array)
 
     ! Test 7: Array with alternating high and low values
     print *, "Test 7: Array with alternating high and low values"
-    if (allocated(array)) deallocate(array)
-    allocate(array(6))
-    array = (/ 1, 1000, 2, 999, 3, 998 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(6))
+    array = (/1, 1000, 2, 999, 3, 998/)
     call run_test(array)
 
     ! Test 8: Empty array
     print *, "Test 8: Empty array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(0))
+    if (allocated(array)) deallocate (array)
+    allocate (array(0))
     call run_test(array)
 
 contains
@@ -88,6 +88,5 @@ contains
 
         print *, ""
     end subroutine run_test
-
 
 end program tests_heap_sort

--- a/tests/sorts/tests_merge_sort.f90
+++ b/tests/sorts/tests_merge_sort.f90
@@ -11,55 +11,55 @@ program tests_merge_sort
 
     ! Test 1: Repeated elements
     print *, "Test 1: Array with repeated elements"
-    array = (/ 4, 2, 7, 3, 1, 4, 9, 5, 10, 9, 2, 1/)
+    array = (/4, 2, 7, 3, 1, 4, 9, 5, 10, 9, 2, 1/)
     call run_test(array)
 
     ! Test 2: Already sorted array
     print *, "Test 2: Already sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 1, 2, 3, 4, 5, 6, 7, 8 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/1, 2, 3, 4, 5, 6, 7, 8/)
     call run_test(array)
 
     ! Test 3: Reverse sorted array
     print *, "Test 3: Reverse sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 8, 7, 6, 5, 4, 3, 2, 1 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/8, 7, 6, 5, 4, 3, 2, 1/)
     call run_test(array)
 
     ! Test 4: Array with all negative numbers
     print *, "Test 4: Array with all negative numbers"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ -11, -55, -43, -70, -2, -1, -15, -9 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/-11, -55, -43, -70, -2, -1, -15, -9/)
     call run_test(array)
 
     ! Test 5: Single element array
     print *, "Test 5: Single element array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(1))
-    array = (/ 62 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(1))
+    array = (/62/)
     call run_test(array)
 
     ! Test 6: Array with identical elements
     print *, "Test 6: Array with identical elements"
-    if (allocated(array)) deallocate(array)
-    allocate(array(5))
-    array = (/ 4, 4, 4, 4, 4 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(5))
+    array = (/4, 4, 4, 4, 4/)
     call run_test(array)
 
     ! Test 7: Array with alternating high and low values
     print *, "Test 7: Array with alternating high and low values"
-    if (allocated(array)) deallocate(array)
-    allocate(array(6))
-    array = (/ 10, 2000, 20, 888, 30, 798 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(6))
+    array = (/10, 2000, 20, 888, 30, 798/)
     call run_test(array)
 
     ! Test 8: Empty array
     print *, "Test 8: Empty array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(0))
+    if (allocated(array)) deallocate (array)
+    allocate (array(0))
     call run_test(array)
 
 contains
@@ -88,6 +88,5 @@ contains
 
         print *, ""
     end subroutine run_test
-
 
 end program tests_merge_sort

--- a/tests/sorts/tests_quick_sort.f90
+++ b/tests/sorts/tests_quick_sort.f90
@@ -11,55 +11,55 @@ program tests_quick_sort
 
     ! Test 1: Repeated elements
     print *, "Test 1: Array with repeated elements"
-    array = (/ 5, 3, 8, 3, 1, 5, 7, 5, 10, 7, 3, 1 /)
+    array = (/5, 3, 8, 3, 1, 5, 7, 5, 10, 7, 3, 1/)
     call run_test(array)
 
     ! Test 2: Already sorted array
     print *, "Test 2: Already sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 1, 2, 3, 4, 5, 6, 7, 8 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/1, 2, 3, 4, 5, 6, 7, 8/)
     call run_test(array)
 
     ! Test 3: Reverse sorted array
     print *, "Test 3: Reverse sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 8, 7, 6, 5, 4, 3, 2, 1 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/8, 7, 6, 5, 4, 3, 2, 1/)
     call run_test(array)
 
     ! Test 4: Array with all negative numbers
     print *, "Test 4: Array with all negative numbers"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ -1, -5, -3, -7, -2, -12, -15, -4 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/-1, -5, -3, -7, -2, -12, -15, -4/)
     call run_test(array)
 
     ! Test 5: Single element array
     print *, "Test 5: Single element array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(1))
-    array = (/ 42 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(1))
+    array = (/42/)
     call run_test(array)
 
     ! Test 6: Array with identical elements
     print *, "Test 6: Array with identical elements"
-    if (allocated(array)) deallocate(array)
-    allocate(array(5))
-    array = (/ 7, 7, 7, 7, 7 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(5))
+    array = (/7, 7, 7, 7, 7/)
     call run_test(array)
 
     ! Test 7: Array with alternating high and low values
     print *, "Test 7: Array with alternating high and low values"
-    if (allocated(array)) deallocate(array)
-    allocate(array(6))
-    array = (/ 1, 1000, 2, 999, 3, 998 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(6))
+    array = (/1, 1000, 2, 999, 3, 998/)
     call run_test(array)
 
     ! Test 8: Empty array
     print *, "Test 8: Empty array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(0))
+    if (allocated(array)) deallocate (array)
+    allocate (array(0))
     call run_test(array)
 
 contains
@@ -88,6 +88,5 @@ contains
 
         print *, ""
     end subroutine run_test
-
 
 end program tests_quick_sort

--- a/tests/sorts/tests_radix_sort.f90
+++ b/tests/sorts/tests_radix_sort.f90
@@ -12,78 +12,78 @@ program tests_radix_sort
 
     ! Test 1: Base 10
     print *, "Test 1: Radix Sort with base 10"
-    if (allocated(array)) deallocate(array)
-    allocate(array(10))
-    array = (/ 170, 45, 75, 90, 802, 24, 2, 66, 15, 40 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(10))
+    array = (/170, 45, 75, 90, 802, 24, 2, 66, 15, 40/)
     call run_test(array, base10)
 
     ! Test 2: Base 2
     print *, "Test 2: Radix Sort with base 2"
-    if (allocated(array)) deallocate(array)
-    allocate(array(10))
-    array = (/ 10, 13, 9, 14, 2, 5, 15, 6, 8, 1 /)  ! Binary values as decimal
+    if (allocated(array)) deallocate (array)
+    allocate (array(10))
+    array = (/10, 13, 9, 14, 2, 5, 15, 6, 8, 1/)  ! Binary values as decimal
     call run_test(array, base2)
 
     ! Test 3: Base 16
     print *, "Test 3: Radix Sort with base 16"
-    if (allocated(array)) deallocate(array)
-    allocate(array(10))
-    array = (/ 171, 31, 61, 255, 16, 5, 211, 42, 180, 0 /)  ! Hexadecimal values as decimal
+    if (allocated(array)) deallocate (array)
+    allocate (array(10))
+    array = (/171, 31, 61, 255, 16, 5, 211, 42, 180, 0/)  ! Hexadecimal values as decimal
     call run_test(array, base16)
 
     ! Test 4: Repeated elements
     print *, "Test 4: Array with repeated elements"
-    if (allocated(array)) deallocate(array)
-    allocate(array(12))
-    array = (/ 5, 3, 8, 3, 1, 5, 7, 5, 10, 7, 3, 1 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(12))
+    array = (/5, 3, 8, 3, 1, 5, 7, 5, 10, 7, 3, 1/)
     call run_test(array, base10)
 
     ! Test 5: Already sorted array
     print *, "Test 5: Already sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 1, 2, 3, 4, 5, 6, 7, 8 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/1, 2, 3, 4, 5, 6, 7, 8/)
     call run_test(array, base10)
 
     ! Test 6: Reverse sorted array
     print *, "Test 6: Reverse sorted array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ 8, 7, 6, 5, 4, 3, 2, 1 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/8, 7, 6, 5, 4, 3, 2, 1/)
     call run_test(array, base10)
 
     ! Test 7: Array with all negative numbers (Note: Radix Sort only handles non-negative integers)
     print *, "Test 7: Array with all negative numbers (handled as base 10)"
-    if (allocated(array)) deallocate(array)
-    allocate(array(8))
-    array = (/ -1, -5, -3, -7, -2, -12, -15, -4 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(8))
+    array = (/-1, -5, -3, -7, -2, -12, -15, -4/)
     call run_test(array, base10)
 
     ! Test 8: Single element array
     print *, "Test 8: Single element array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(1))
-    array = (/ 42 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(1))
+    array = (/42/)
     call run_test(array, base10)
 
     ! Test 9: Array with identical elements
     print *, "Test 9: Array with identical elements"
-    if (allocated(array)) deallocate(array)
-    allocate(array(5))
-    array = (/ 7, 7, 7, 7, 7 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(5))
+    array = (/7, 7, 7, 7, 7/)
     call run_test(array, base10)
 
     ! Test 10: Array with alternating high and low values
     print *, "Test 10: Array with alternating high and low values"
-    if (allocated(array)) deallocate(array)
-    allocate(array(6))
-    array = (/ 1, 1000, 2, 999, 3, 998 /)
+    if (allocated(array)) deallocate (array)
+    allocate (array(6))
+    array = (/1, 1000, 2, 999, 3, 998/)
     call run_test(array, base10)
 
     ! Test 11: Empty array
     print *, "Test 11: Empty array"
-    if (allocated(array)) deallocate(array)
-    allocate(array(0))
+    if (allocated(array)) deallocate (array)
+    allocate (array(0))
     call run_test(array, base10)
 
 contains


### PR DESCRIPTION
This PR adds a workflow, which checks the used code formatting (and makes the necessary changes in the currently existing files).

As suggested by @Ramy-Badr-Ahmed in #13, the new workflow uses [`fprettify`](https://github.com/fortran-lang/fprettify). I could not force it to fail, if there are some changes necessary, so I used a _fail if needs reformatting_ approach as in TheAlgorithms/Nim#19.

Beside the indentation size being set to `4`, I used the default setting of the `fprettify`. Please let me know if you prefer other settings.

The _failing part_ works [logs](https://github.com/TheAlgorithms/Fortran/actions/runs/11021300048/job/30608062137) for 8663d150dc0a7c6c9fbc49e74405cd7bdd508c43.