### PR TITLE
fix: update `tests_square_root.f90` to fix the CI

### DIFF
--- a/tests/maths/tests_square_root.f90
+++ b/tests/maths/tests_square_root.f90
@@ -47,7 +47,7 @@ contains
 
     ! Test case 4: Square root of a non-perfect square (e.g., 2)
     subroutine test_sqrt_non_perfect_square()
-        expected = 1.41421356
+        expected = 1.4142136
         result = calculate_sqrt(2.0)
         call assert_test(result, expected, "Test 4: Square root of 2", tolerance)
     end subroutine test_sqrt_non_perfect_square


### PR DESCRIPTION
The literal had too many digits to fit into `REAL(4)`. Also the test was moved to the `tests`.

This PR fixes the (failing CI](https://github.com/TheAlgorithms/Fortran/actions/runs/19780100964/).

@ITZ-NIHALPATEL: please have a look.