### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/.github/workflows/"
+    schedule:
+      interval: "weekly"
+...


### PR DESCRIPTION
Some of the dependencies are not up to date, cf. 

https://github.com/TheAlgorithms/Fortran/blob/90121d40af20d1c3df4114cda730666d2e336087/.github/workflows/ci.yml#L24

This PR configures dependabot, to update them update them when needed.